### PR TITLE
Add support for mono audio channel handling

### DIFF
--- a/src/aac_decoder/aac_decoder.cpp
+++ b/src/aac_decoder/aac_decoder.cpp
@@ -2,7 +2,7 @@
  *  aac_decoder.cpp
  *  faad2 - ESP32 adaptation
  *  Created on: 12.09.2023
- *  Updated on: 16.07.2026
+ *  Updated on: 18.07.2026
  */
 
 #include "aac_decoder.h"
@@ -164,6 +164,14 @@ int32_t AACDecoder::decode(uint8_t* inbuf, int32_t* bytesLeft, int32_t* outbuf) 
             if(getErrorMessage(abs(err)).level == AAC_VERBOSE) AAC_LOG_VERBOSE("{}", getErrorMessage(abs(err)).text);
         }
     } else {
+        if (m_aacChannels == 1 && !m_frameInfo.isPS) { // ESP32-S3 and -P4 has ParametricStereo activated
+            AAC_LOG_ERROR("1");
+            for (int32_t i = m_validSamples - 1; i >= 0; i--) {
+                int32_t sample = outbuf[i];
+                outbuf[i * 2] = sample;
+                outbuf[i * 2 + 1] = sample;
+            }
+        }
     }
     return err;
 }


### PR DESCRIPTION
Handle mono audio channels for ESP32-S3 and -P4 by duplicating samples.